### PR TITLE
fix(eloquent): soft delete is broken on PostgreSQL; honour declared timestamp casts

### DIFF
--- a/framework/src/database/mod.rs
+++ b/framework/src/database/mod.rs
@@ -55,7 +55,7 @@ pub mod identifier;
 pub mod model;
 // Internal: hand-written SQL in the queue / notification stores renders its
 // placeholders through here so Postgres gets `$1` instead of `?`.
-pub(crate) mod placeholder;
+pub mod placeholder;
 pub mod query_builder;
 pub mod route_binding;
 pub mod testing;

--- a/framework/src/database/placeholder.rs
+++ b/framework/src/database/placeholder.rs
@@ -17,7 +17,7 @@ use sea_orm::DatabaseBackend;
 ///
 /// `n` is ignored outside Postgres because `?` carries no ordinal — callers
 /// still pass it so the same numbering logic reads identically at every site.
-pub(crate) fn placeholder(backend: DatabaseBackend, n: usize) -> String {
+pub fn placeholder(backend: DatabaseBackend, n: usize) -> String {
     match backend {
         DatabaseBackend::Postgres => format!("${n}"),
         _ => "?".to_string(),
@@ -32,7 +32,7 @@ pub(crate) fn placeholder(backend: DatabaseBackend, n: usize) -> String {
 /// binds (the queue filter's `IN` list sits behind two timestamp binds) must
 /// continue the statement's numbering or Postgres silently reads the wrong
 /// parameter.
-pub(crate) fn placeholder_list(backend: DatabaseBackend, start: usize, count: usize) -> String {
+pub fn placeholder_list(backend: DatabaseBackend, start: usize, count: usize) -> String {
     (start..start + count)
         .map(|n| placeholder(backend, n))
         .collect::<Vec<_>>()

--- a/suprnova-macros/src/model/derive_eloquent.rs
+++ b/suprnova-macros/src/model/derive_eloquent.rs
@@ -707,10 +707,6 @@ pub fn emit(input: &ModelInput) -> Result<TokenStream> {
                     let now = ::suprnova::chrono::Utc::now().to_rfc3339();
                     let table = <Self as ::suprnova::eloquent::EloquentModel>::TABLE;
                     let pk_name = <Self as ::suprnova::eloquent::Model>::primary_key_name();
-                    let sql = ::std::format!(
-                        "UPDATE {table} SET {} = ? WHERE {pk_name} = ?",
-                        #soft_delete_col,
-                    );
                     // Route through `resolve_write` so the tombstone
                     // UPDATE honours the full write-side precedence chain
                     // — tx override → ambient CURRENT_TX → per-model
@@ -724,6 +720,16 @@ pub fn emit(input: &ModelInput) -> Result<TokenStream> {
                     )
                     .await?;
                     let backend = exec.backend();
+                    // Placeholders are backend-specific: Postgres rejects a
+                    // bare `?` at parse time. Render them through the
+                    // framework's own helper, as every other hand-written
+                    // statement already does.
+                    let sql = ::std::format!(
+                        "UPDATE {table} SET {} = {} WHERE {pk_name} = {}",
+                        #soft_delete_col,
+                        ::suprnova::database::placeholder::placeholder(backend, 1),
+                        ::suprnova::database::placeholder::placeholder(backend, 2),
+                    );
                     exec.run(
                         ::suprnova::sea_orm::Statement::from_sql_and_values(
                             backend,
@@ -764,10 +770,6 @@ pub fn emit(input: &ModelInput) -> Result<TokenStream> {
 
                     let table = <Self as ::suprnova::eloquent::EloquentModel>::TABLE;
                     let pk_name = <Self as ::suprnova::eloquent::Model>::primary_key_name();
-                    let sql = ::std::format!(
-                        "UPDATE {table} SET {} = NULL WHERE {pk_name} = ?",
-                        #soft_delete_col,
-                    );
                     // Route through `resolve_write` (not `resolve`) so
                     // restores honour the full write-side precedence
                     // chain — tx override → ambient CURRENT_TX → builder
@@ -782,6 +784,12 @@ pub fn emit(input: &ModelInput) -> Result<TokenStream> {
                     )
                     .await?;
                     let backend = exec.backend();
+                    // Same helper as in delete(): Postgres rejects a bare `?`.
+                    let sql = ::std::format!(
+                        "UPDATE {table} SET {} = NULL WHERE {pk_name} = {}",
+                        #soft_delete_col,
+                        ::suprnova::database::placeholder::placeholder(backend, 1),
+                    );
                     exec.run(
                         ::suprnova::sea_orm::Statement::from_sql_and_values(
                             backend,

--- a/suprnova-macros/src/model/derive_eloquent.rs
+++ b/suprnova-macros/src/model/derive_eloquent.rs
@@ -435,6 +435,21 @@ pub fn emit(input: &ModelInput) -> Result<TokenStream> {
     let created_col_ident = quote::format_ident!("{}", input.created_at);
     let updated_col_ident = quote::format_ident!("{}", input.updated_at);
 
+    // The cast that governs each timestamp column — the one the user
+    // declared, or the `AsDateTime` the parser auto-injects for a
+    // `DateTime<Utc>` field. Every other read and write path already
+    // routes through `cast_for_field`; the timestamp injection below
+    // named `AsDateTime` literally, which pinned created_at / updated_at
+    // to `Storage = String` no matter what the field declared.
+    let created_cast: ::syn::Type = input
+        .cast_for_field(&input.created_at)
+        .cloned()
+        .unwrap_or_else(|| ::syn::parse_quote!(::suprnova::AsDateTime));
+    let updated_cast: ::syn::Type = input
+        .cast_for_field(&input.updated_at)
+        .cloned()
+        .unwrap_or_else(|| ::syn::parse_quote!(::suprnova::AsDateTime));
+
     // ---- unique_id PK generation (HasUuids / HasUlids analogue) -------
     //
     // When `#[model(unique_id = "uuid" | "uuid_v4" | "ulid")]` is set,
@@ -486,7 +501,7 @@ pub fn emit(input: &ModelInput) -> Result<TokenStream> {
             // update(attrs) in one place.
             let __suprnova_now = ::suprnova::chrono::Utc::now();
             am.#updated_col_ident = ::suprnova::sea_orm::Set(
-                <::suprnova::AsDateTime as ::suprnova::eloquent::casts::Cast>::to_storage(
+                <#updated_cast as ::suprnova::eloquent::casts::Cast>::to_storage(
                     &__suprnova_now,
                 )?,
             );
@@ -498,7 +513,7 @@ pub fn emit(input: &ModelInput) -> Result<TokenStream> {
                 ::suprnova::sea_orm::ActiveValue::NotSet
             ) {
                 am.#created_col_ident = ::suprnova::sea_orm::Set(
-                    <::suprnova::AsDateTime as ::suprnova::eloquent::casts::Cast>::to_storage(
+                    <#created_cast as ::suprnova::eloquent::casts::Cast>::to_storage(
                         &__suprnova_now,
                     )?,
                 );
@@ -516,7 +531,7 @@ pub fn emit(input: &ModelInput) -> Result<TokenStream> {
             // the caller didn't touch it.
             let __suprnova_now = ::suprnova::chrono::Utc::now();
             am.#updated_col_ident = ::suprnova::sea_orm::Set(
-                <::suprnova::AsDateTime as ::suprnova::eloquent::casts::Cast>::to_storage(
+                <#updated_cast as ::suprnova::eloquent::casts::Cast>::to_storage(
                     &__suprnova_now,
                 )?,
             );
@@ -548,7 +563,7 @@ pub fn emit(input: &ModelInput) -> Result<TokenStream> {
                         as ::core::default::Default>::default();
                     am.#pk_ident = ::suprnova::sea_orm::ActiveValue::Unchanged(self.#pk_ident.clone());
                     am.#updated_col_ident = ::suprnova::sea_orm::Set(
-                        <::suprnova::AsDateTime as ::suprnova::eloquent::casts::Cast>::to_storage(
+                        <#updated_cast as ::suprnova::eloquent::casts::Cast>::to_storage(
                             &now,
                         )?,
                     );
@@ -602,6 +617,15 @@ pub fn emit(input: &ModelInput) -> Result<TokenStream> {
     //   `delete(self)`.
     let soft_deletes_enabled = input.soft_deletes;
     let soft_delete_col = &input.soft_deletes_column;
+
+    // Same reasoning as the timestamp casts above: the tombstone UPDATE
+    // bound a hardcoded RFC3339 string, which pinned the soft-delete
+    // column to TEXT even when the field declared a cast with a native
+    // `Storage`.
+    let deleted_cast: ::syn::Type = input
+        .cast_for_field(soft_delete_col)
+        .cloned()
+        .unwrap_or_else(|| ::syn::parse_quote!(::suprnova::AsOptionalDateTime));
     let soft_delete_col_ident = quote::format_ident!("{}", soft_delete_col);
     let key_type = &input.key_type;
 
@@ -704,7 +728,9 @@ pub fn emit(input: &ModelInput) -> Result<TokenStream> {
                 pub async fn delete(self) -> ::core::result::Result<(), ::suprnova::FrameworkError> {
                     <Self as ::suprnova::eloquent::events::ModelEventHooks>::__dispatch_deleting(&self, false).await?;
 
-                    let now = ::suprnova::chrono::Utc::now().to_rfc3339();
+                    let now = <#deleted_cast as ::suprnova::eloquent::casts::Cast>::to_storage(
+                        &::core::option::Option::Some(::suprnova::chrono::Utc::now()),
+                    )?;
                     let table = <Self as ::suprnova::eloquent::EloquentModel>::TABLE;
                     let pk_name = <Self as ::suprnova::eloquent::Model>::primary_key_name();
                     // Route through `resolve_write` so the tombstone
@@ -735,9 +761,7 @@ pub fn emit(input: &ModelInput) -> Result<TokenStream> {
                             backend,
                             &sql,
                             ::std::vec![
-                                ::suprnova::sea_orm::Value::String(
-                                    ::core::option::Option::Some(::std::boxed::Box::new(now)),
-                                ),
+                                ::suprnova::sea_orm::Value::from(now),
                                 ::suprnova::eloquent::model::json_value_to_sea_value(
                                     &<Self as ::suprnova::eloquent::Model>::primary_key_value_json(&self),
                                 ),


### PR DESCRIPTION
# Pull request: soft delete on PostgreSQL

Two commits, independent — the first is a bug fix and can be taken on
its own.

Based on current `main`. `cargo check --workspace` is clean and
`cargo test -p suprnova --lib` passes 1573 tests with both changes
applied.

---

## 1. `fix(eloquent): render soft-delete placeholders per backend`

**`Model::delete()` and `Model::restore()` do not work on PostgreSQL.**
Not for a particular model — for every model that declares
`soft_deletes`.

```
Execution Error: error returned from database:
syntax error at or near "WHERE"
```

The macro builds the tombstone UPDATE by hand and embeds a literal `?`:

```rust
let sql = format!("UPDATE {table} SET {} = ? WHERE {pk_name} = ?", soft_delete_col);
```

Postgres rejects a bare `?` at parse time, so the statement never
reaches a row. SQLite and MySQL accept it, which is why this is not
caught by the suite.

The framework already has the answer. `framework/src/database/placeholder.rs`
exists for exactly this, and its own module doc states the rule:

> Hard-coding `?` therefore isn't a portability wart, it's an outage on
> one of the three first-class backends, so every hand-written statement
> routes its placeholders through here rather than embedding a literal.

The soft-delete macro was the only site that did not follow it.

**Fix.** Both statements are assembled after the backend is known and
render placeholders through `placeholder(backend, n)`. The helper and
its module move from `pub(crate)` to `pub`, because the calling code is
emitted into the downstream crate, not compiled inside the framework.

**Compatibility.** None for SQLite and MySQL users: the helper returns
`?` for both, so the generated SQL is byte-identical.

### Reproducing

Any model with `soft_deletes` against a PostgreSQL connection:

```rust
#[model(table = "grants", soft_deletes, timestamps)]
pub struct Grant { /* … */ }

grant.delete().await?;   // Err: syntax error at or near "WHERE"
```

---

## 2. `feat(eloquent): honour the declared cast when writing timestamps`

Every read and write path resolves a field's cast through
`input.cast_for_field(name)` — except three: the `created_at` /
`updated_at` injection and the tombstone, which name `AsDateTime`
literally.

`AsDateTime` has `type Storage = String`, so those three columns are
pinned to TEXT whatever the field declares. A model whose migration uses
`timestamptz` fails at runtime:

```
column "created_at" is of type timestamp with time zone
but expression is of type text
```

**Fix.** Look the cast up at the write site. The parser already
auto-injects `AsDateTime` for a bare `DateTime<Utc>` field, and a
user-declared cast wins over that injection, so the default stays
byte-identical — but a model can now keep its timestamps in a native
column type:

```rust
pub struct AsUtcTime;

impl Cast for AsUtcTime {
    type Runtime = DateTime<Utc>;
    type Storage = DateTime<FixedOffset>;

    fn to_storage(v: &Self::Runtime) -> Result<Self::Storage, FrameworkError> {
        Ok((*v).into())
    }

    fn from_storage(s: &Self::Storage) -> Result<Self::Runtime, FrameworkError> {
        Ok(s.with_timezone(&Utc))
    }
}

#[model(
    table = "grants",
    casts = { created_at = AsUtcTime, updated_at = AsUtcTime, deleted_at = AsOptionalUtcTime },
    soft_deletes,
    timestamps,
)]
pub struct Grant { /* … */ }
```

The tombstone additionally binds through `Value::from(storage)` instead
of `Value::String`, so a native storage type reaches the driver as
itself.

**Verified** against PostgreSQL 18: with the casts declared, all three
columns land in `timestamptz` and date arithmetic works in SQL
(`ends_at - now()`, `ends_at < now() + interval '3 days'`). Without
them the emitted code is unchanged.

---

## Why this came up

We are building a messaging bridge on Suprnova 1.2.4 with PostgreSQL and
soft deletes on every table. Both defects surfaced on the first run of
the first feature, within minutes of each other.

Happy to split these into two pull requests, add tests in whatever shape
you prefer, or adjust the public surface of `placeholder` if you would
rather expose it differently.
